### PR TITLE
Use reitit-ring

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,4 +5,9 @@
         ring/ring-core {:mvn/version "1.7.0-RC1"}
         ring/ring-jetty-adapter {:mvn/version "1.7.0-RC1"}
         tea-time {:mvn/version "1.0.0"}
-        metosin/jsonista {:mvn/version "0.2.1"}}}
+        metosin/reitit-core {:mvn/version "0.1.3"}
+        metosin/reitit-ring {:mvn/version "0.1.3"}
+        metosin/reitit-spec {:mvn/version "0.1.3"}
+        metosin/reitit-swagger {:mvn/version "0.1.3"}
+        metosin/reitit-swagger-ui {:mvn/version "0.1.3"}
+        metosin/muuntaja {:mvn/version "0.6.0-alpha1"}}}

--- a/src/cljdoc/clojars_stats/api.clj
+++ b/src/cljdoc/clojars_stats/api.clj
@@ -2,40 +2,40 @@
   (:require [cljdoc.clojars-stats.db :as db]
             [ring.middleware.params :as params]
             [ring.adapter.jetty :as jetty]
-            [jsonista.core :as j]
-            [clojure.string :as string]))
+            [reitit.ring :as ring]
+            [reitit.ring.coercion]
+            [reitit.coercion.spec]
+            [reitit.swagger :as swagger]
+            [reitit.swagger-ui :as swagger-ui]
+            [muuntaja.middleware]))
 
 (def exposed-queries
   ;; NEVER change those map entries, only add new stuff as needed
   {"/artifact-monthly" {:query-fn db/artifact-monthly
-                        :params [:group_id :artifact_id]}})
-
-(def index-page
-  (->> ["<pre>"
-        "Various endpoints are available:\n"
-        (for [[k {:keys [params]}] exposed-queries]
-          (str k " query-params: " (mapv name params) "\n"))
-        "\nContribute more at https://github.com/cljdoc/clojars-stats"
-        "</pre>"]
-       flatten
-       (string/join "\n")))
+                        :summary "get downloads per timespan"
+                        :params {:group_id string?
+                                 :artifact_id string?}}})
 
 (defn make-handler [db]
-  (fn handler [{:keys [uri query-params]}]
-    (if (= "/" uri)
-      {:status 200 :body index-page}
-      (if-let [{:keys [query-fn params]} (get exposed-queries uri)]
-        (if (every? query-params (map name params))
-          {:status 200
-           :headers {"Content-Type" "application/json"}
-           :body (->> (for [p params] [p (get query-params (name p))])
-                      (into {})
-                      (query-fn db)
-                      (j/write-value-as-string))}
-          {:status 400
-           :body (format "Insufficient parameters:\nProvided: %s\nExpected: %s" query-params params)})
-        {:status 404
-         :body (format "Unknown query: %s" uri)}))))
+  (ring/ring-handler
+    (ring/router
+      [["/swagger.json" {:get {:no-doc true
+                               :handler (swagger/create-swagger-handler)}}]
+       (for [[path {:keys [query-fn params summary]}] exposed-queries]
+         [path {:get {:parameters {:query params}
+                      :swagger {:summary summary}
+                      :handler (fn [request]
+                                 {:status 200
+                                  :body (query-fn db (get-in request [:parameters :query]))})}}])]
+      {:data {:coercion reitit.coercion.spec/coercion
+              :middleware [reitit.ring.coercion/coerce-request-middleware
+                           muuntaja.middleware/wrap-format]
+              :swagger {:id ::clojars-stats
+                        :info {:title "Clojars Stats API"
+                               :description "Contribute more at https://github.com/cljdoc/clojars-stats"}}}})
+    (ring/routes
+      (swagger-ui/create-swagger-ui-handler {:path "/"})
+      (ring/create-default-handler))))
 
 (defn start! [{:keys [db port]}]
   (assert (and db port))

--- a/src/cljdoc/clojars_stats/api.clj
+++ b/src/cljdoc/clojars_stats/api.clj
@@ -28,8 +28,9 @@
                                  {:status 200
                                   :body (query-fn db (get-in request [:parameters :query]))})}}])]
       {:data {:coercion reitit.coercion.spec/coercion
-              :middleware [reitit.ring.coercion/coerce-request-middleware
-                           muuntaja.middleware/wrap-format]
+              :middleware [muuntaja.middleware/wrap-format
+                           reitit.ring.coercion/coerce-exceptions-middleware
+                           reitit.ring.coercion/coerce-request-middleware]
               :swagger {:id ::clojars-stats
                         :info {:title "Clojars Stats API"
                                :description "Contribute more at https://github.com/cljdoc/clojars-stats"}}}})


### PR DESCRIPTION
Sample how it would look like using [reitit-ring](https://clojars.org/metosin/reitit). Same number of lines in the `api` ns, but does also request parameter validation (via the coercion middleware), serves json, transit and edn (via muuntaja), emits swagger-spec (via reitit-swagger) and serves the swagger-ui (via reitit-swagger-ui).

<img width="750" alt="screen shot 2018-07-20 at 15 01 05" src="https://user-images.githubusercontent.com/567532/43001416-d372cee2-8c2d-11e8-8e77-6efbffeee08c.png">
