### PR TITLE
Disable online swagger validator

### DIFF
--- a/src/cljdoc/clojars_stats/api.clj
+++ b/src/cljdoc/clojars_stats/api.clj
@@ -36,7 +36,8 @@
                                :description "Contribute more at https://github.com/cljdoc/clojars-stats"}}}})
     (ring/routes
       (swagger-ui/create-swagger-ui-handler {:path "/"
-                                             :config {:doc-expansion "list"}})
+                                             :config {:doc-expansion "list"
+                                                      :validator-url nil}})
       (ring/create-default-handler))))
 
 (defn start! [{:keys [db port]}]


### PR DESCRIPTION
The validator is not needed and currently, reitit-swagger emits too much swagger-data causing errors. Will be resolved in https://github.com/metosin/reitit/issues/116